### PR TITLE
Add review status checking

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -78,9 +78,15 @@ async function handlePullRequestUpdate(context, eventName, event) {
 }
 
 async function handlePullRequestReviewUpdate(context, eventName, event) {
-  const { action } = event;
+  const { action, review } = event;
   if (action === "submitted") {
-    await updateAndMergePullRequest(context, event.pull_request);
+    if (review.state === "approved") {
+      await updateAndMergePullRequest(context, event.pull_request);
+    } else {
+      logger.info("Review state is not approved:", review.state);
+      logger.info("Action ignored:", eventName, action);
+      throw new NeutralExitError();
+    }
   } else {
     logger.info("Action ignored:", eventName, action);
     throw new NeutralExitError();


### PR DESCRIPTION
When review status is not "approved", this action continues also merging like below.
So I added pull_request_review's [review object status](https://developer.github.com/v3/activity/events/types/#pullrequestreviewevent) before merging.

![image](https://user-images.githubusercontent.com/2971112/65847645-56e86a00-e37d-11e9-9f71-d7798a47024c.png)

