### PR TITLE
Add custom commit message support

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,11 +95,12 @@ The following environment variables are supported:
   be merged the same way as pull requests with branches from the main
   repository. Set this option to `false` to disable merging of pull requests
   from forked repositories.
-- `COMMIT_MESSAGE`: Specify the commit message to use when merging the pull
-  request into the base branch. Possible values are `automatic` (use git's
-  automatic message), `pull-request-title` (use the Pull Request's title),
-  `pull-request-description` (use the Pull Request's description), and
-  `pull-request-title-and-description`. The default value is `automatic`.
+- `COMMIT_MESSAGE_TEMPLATE`: Specify the commit message template to use when
+  merging the pull request into the base branch. Possible values are
+  `automatic` (use git's automatic message), `pull-request-title` (use the Pull
+  Request's title), `pull-request-description` (use the Pull Request's
+  description), and `pull-request-title-and-description`. The default value is
+  `automatic`.
 - `TOKEN`: In some cases it can be useful to run this action as a certain user
   (by default, it will run as `github-actions`). This can be useful if you want
   to use the _Restrict who can push to matching branches_ option in the branch

--- a/README.md
+++ b/README.md
@@ -95,6 +95,11 @@ The following environment variables are supported:
   be merged the same way as pull requests with branches from the main
   repository. Set this option to `false` to disable merging of pull requests
   from forked repositories.
+- `COMMIT_MESSAGE`: Specify the commit message to use when merging the pull
+  request into the base branch. Possible values are `automatic` (use git's
+  automatic message), `pull-request-title` (use the Pull Request's title),
+  `pull-request-description` (use the Pull Request's description), and
+  `pull-request-title-and-description`. The default value is `automatic`.
 - `TOKEN`: In some cases it can be useful to run this action as a certain user
   (by default, it will run as `github-actions`). This can be useful if you want
   to use the _Restrict who can push to matching branches_ option in the branch
@@ -118,6 +123,7 @@ You can configure the environment variables in the workflow file like this:
           AUTOREBASE: "ready-to-rebase-and-merge"
           MERGE_METHOD: "squash"
           MERGE_FORKS: "false"
+          COMMIT_MESSAGE: "pull-request-description"
 ```
 
 ## License

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ You can configure the environment variables in the workflow file like this:
           AUTOREBASE: "ready-to-rebase-and-merge"
           MERGE_METHOD: "squash"
           MERGE_FORKS: "false"
-          COMMIT_MESSAGE: "pull-request-description"
+          COMMIT_MESSAGE_TEMPLATE: "pull-request-description"
 ```
 
 ## License

--- a/bin/automerge.js
+++ b/bin/automerge.js
@@ -52,8 +52,8 @@ async function main() {
   const autorebase = process.env.AUTOREBASE || "autorebase";
   const mergeMethod = process.env.MERGE_METHOD || "merge";
   const mergeForks = process.env.MERGE_FORKS !== "false";
-  const commitMessage = process.env.COMMIT_MESSAGE || "automatic";
-  const config = { labels, automerge, autorebase, mergeMethod, mergeForks, commitMessage };
+  const commitMessageTemplate = process.env.COMMIT_MESSAGE_TEMPLATE || "automatic";
+  const config = { labels, automerge, autorebase, mergeMethod, mergeForks, commitMessageTemplate };
 
   logger.debug("Configuration:", config);
 

--- a/bin/automerge.js
+++ b/bin/automerge.js
@@ -52,7 +52,8 @@ async function main() {
   const autorebase = process.env.AUTOREBASE || "autorebase";
   const mergeMethod = process.env.MERGE_METHOD || "merge";
   const mergeForks = process.env.MERGE_FORKS !== "false";
-  const config = { labels, automerge, autorebase, mergeMethod, mergeForks };
+  const commitMessage = process.env.COMMIT_MESSAGE || "automatic";
+  const config = { labels, automerge, autorebase, mergeMethod, mergeForks, commitMessage };
 
   logger.debug("Configuration:", config);
 

--- a/lib/merge.js
+++ b/lib/merge.js
@@ -8,11 +8,12 @@ const RETRY_SLEEP = 10000;
 async function merge(context, pullRequest, head) {
   const {
     octokit,
-    config: { mergeMethod, commitMessage }
+    config: { mergeMethod, commitMessageTemplate }
   } = context;
 
   await waitUntilReady(octokit, pullRequest);
 
+  const commitMessage = getCommitMessage(commitMessageTemplate);
   await tryMerge(octokit, pullRequest, head, mergeMethod, commitMessage);
 
   logger.info("PR successfully merged!");
@@ -76,13 +77,27 @@ async function tryMerge(octokit, pullRequest, head, mergeMethod, commitMessage) 
   );
 }
 
+function getCommitMessage(commitMessageTemplate, pullRequest) {
+  if (commitMessageTemplate === "automatic") {
+    return undefined;
+  } else if (commitMessageTemplate === "pull-request-title") {
+    return pullRequest.title;
+  } else if (commitMessageTemplate === "pull-request-description") {
+    return pullRequest.body;
+  } else if (commitMessageTemplate === "pull-request-title-and-description") {
+    return pullRequest.title + "\n\n" + pullRequest.body;
+  } else {
+    throw new Error(`Unknown commit message value: ${commitMessageTemplate}`);
+  }
+}
+
 async function mergePullRequest(octokit, pullRequest, head, mergeMethod, commitMessage) {
   try {
     await octokit.pulls.merge({
       owner: pullRequest.head.repo.owner.login,
       repo: pullRequest.head.repo.name,
       pull_number: pullRequest.number,
-      commit_message: getCommitMessage(commitMessage, pullRequest),
+      commit_message: commitMessage,
       sha: head,
       merge_method: mergeMethod
     });
@@ -90,20 +105,6 @@ async function mergePullRequest(octokit, pullRequest, head, mergeMethod, commitM
   } catch (e) {
     logger.info("Failed to merge PR:", e.message);
     return false;
-  }
-}
-
-function getCommitMessage(commitMessage, pullRequest) {
-  if (commitMessage === "automatic") {
-    return undefined;
-  } else if (commitMessage === "pull-request-title") {
-    return pullRequest.title;
-  } else if (commitMessage === "pull-request-description") {
-    return pullRequest.body;
-  } else if (commitMessage === "pull-request-title-and-description") {
-    return pullRequest.title + "\n\n" + pullRequest.body;
-  } else {
-    throw new Error(`Unknown commit message value: ${commitMessage}`);
   }
 }
 

--- a/lib/merge.js
+++ b/lib/merge.js
@@ -8,12 +8,12 @@ const RETRY_SLEEP = 10000;
 async function merge(context, pullRequest, head) {
   const {
     octokit,
-    config: { mergeMethod }
+    config: { mergeMethod, commitMessage }
   } = context;
 
   await waitUntilReady(octokit, pullRequest);
 
-  await tryMerge(octokit, pullRequest, head, mergeMethod);
+  await tryMerge(octokit, pullRequest, head, mergeMethod, commitMessage);
 
   logger.info("PR successfully merged!");
 }
@@ -62,13 +62,13 @@ async function getPullRequest(octokit, pullRequest) {
   return pr;
 }
 
-async function tryMerge(octokit, pullRequest, head, mergeMethod) {
+async function tryMerge(octokit, pullRequest, head, mergeMethod, commitMessage) {
   const retries = 3;
   await retry(
     retries,
     RETRY_SLEEP,
-    () => mergePullRequest(octokit, pullRequest, head, mergeMethod),
-    () => mergePullRequest(octokit, pullRequest, head, mergeMethod),
+    () => mergePullRequest(octokit, pullRequest, head, mergeMethod, commitMessage),
+    () => mergePullRequest(octokit, pullRequest, head, mergeMethod, commitMessage),
     () => {
       logger.info("PR could not be merged after", retries, "tries");
       throw new NeutralExitError();
@@ -76,12 +76,13 @@ async function tryMerge(octokit, pullRequest, head, mergeMethod) {
   );
 }
 
-async function mergePullRequest(octokit, pullRequest, head, mergeMethod) {
+async function mergePullRequest(octokit, pullRequest, head, mergeMethod, commitMessage) {
   try {
     await octokit.pulls.merge({
       owner: pullRequest.head.repo.owner.login,
       repo: pullRequest.head.repo.name,
       pull_number: pullRequest.number,
+      commit_message: getCommitMessage(commitMessage, pullRequest),
       sha: head,
       merge_method: mergeMethod
     });
@@ -89,6 +90,20 @@ async function mergePullRequest(octokit, pullRequest, head, mergeMethod) {
   } catch (e) {
     logger.info("Failed to merge PR:", e.message);
     return false;
+  }
+}
+
+function getCommitMessage(commitMessage, pullRequest) {
+  if (commitMessage === "automatic") {
+    return undefined;
+  } else if (commitMessage === "pull-request-title") {
+    return pullRequest.title;
+  } else if (commitMessage === "pull-request-description") {
+    return pullRequest.body;
+  } else if (commitMessage === "pull-request-title-and-description") {
+    return pullRequest.title + "\n\n" + pullRequest.body;
+  } else {
+    throw new Error(`Unknown commit message value: ${commitMessage}`);
   }
 }
 


### PR DESCRIPTION
This change adds support for custom commit messages via the `COMMIT_MESSAGE_TEMPLATE` environment variable. See the description and example in the README for supported values.

How Verified:

* Verified in a private repo  that `automatic`, `pull-request-title`, `pull-request-description`, and `pull-request-title-and-description` work as expected
* Verified [in a public repo][invalid-message-template-check] that invalid `COMMIT_MESSAGE_TEMPLATE` values cause a failed check

Closes #15

[invalid-message-template-check]: https://github.com/rgardner/automerge-action-test/pull/7/checks?check_run_id=260163614