### PR TITLE
Update merge and update strategy

### DIFF
--- a/bin/automerge.js
+++ b/bin/automerge.js
@@ -48,17 +48,19 @@ async function main() {
   });
 
   const labels = parseLabels(process.env.LABELS);
-  const automerge = process.env.AUTOMERGE || "automerge";
-  const autorebase = process.env.AUTOREBASE || "autorebase";
+  const mergeLabel = process.env.MERGE_LABEL || "automerge";
+  const updateLabel = process.env.UPDATE_LABEL || "automerge";
   const mergeMethod = process.env.MERGE_METHOD || "merge";
+  const updateMethod = process.env.UPDATE_METHOD || "merge";
   const mergeForks = process.env.MERGE_FORKS !== "false";
   const commitMessageTemplate =
     process.env.COMMIT_MESSAGE_TEMPLATE || "automatic";
   const config = {
     labels,
-    automerge,
-    autorebase,
+    mergeLabel,
+    updateLabel,
     mergeMethod,
+    updateMethod,
     mergeForks,
     commitMessageTemplate
   };

--- a/it/it.js
+++ b/it/it.js
@@ -13,10 +13,12 @@ async function main() {
   });
 
   const labels = { required: [], blocking: [] };
-  const automerge = "it-automerge";
-  const autorebase = "it-autorebase";
+  const mergeLabel = "it-merge";
+  const updateLabel = "it-update";
+  const updateAndMergeLabel = "it-update-and-merge";
   const mergeMethod = "merge";
-  const config = { labels, automerge, autorebase, mergeMethod };
+  const updateMethod = "merge";
+  const config = { labels, mergeLabel, updateLabel, updateAndMergeLabel, mergeMethod, updateMethod };
 
   const context = { token, octokit, config };
 

--- a/lib/api.js
+++ b/lib/api.js
@@ -77,14 +77,14 @@ async function handlePullRequestUpdate(context, eventName, event) {
     throw new NeutralExitError();
   }
 
-  await updateAndMergePullRequest(context, event.pull_request);
+  await handlePullRequest(context, event.pull_request);
 }
 
 async function handlePullRequestReviewUpdate(context, eventName, event) {
   const { action, review } = event;
   if (action === "submitted") {
     if (review.state === "approved") {
-      await updateAndMergePullRequest(context, event.pull_request);
+      await handlePullRequest(context, event.pull_request);
     } else {
       logger.info("Review state is not approved:", review.state);
       logger.info("Action ignored:", eventName, action);
@@ -122,7 +122,7 @@ async function handleStatusUpdate(context, eventName, event) {
     let updated = 0;
     for (const pullRequest of pullRequests) {
       try {
-        await updateAndMergePullRequest(context, pullRequest);
+        await handlePullRequest(context, pullRequest);
         ++updated;
       } catch (e) {
         if (e instanceof NeutralExitError) {
@@ -140,7 +140,7 @@ async function handleStatusUpdate(context, eventName, event) {
   }
 }
 
-async function updateAndMergePullRequest(context, pullRequest) {
+async function handlePullRequest(context, pullRequest) {
   if (pullRequest.state !== "open") {
     logger.info("PR is not open:", pullRequest.state);
     throw new NeutralExitError();
@@ -152,14 +152,24 @@ async function updateAndMergePullRequest(context, pullRequest) {
 
   const { token } = context;
 
+  let { sha } = pullRequest.head;
   const repo = pullRequest.head.repo.full_name;
   const cloneUrl = `https://x-access-token:${token}@github.com/${repo}.git`;
 
-  const head = await tmpdir(path =>
-    update(context, path, cloneUrl, pullRequest)
-  );
+  try {
+    await tmpdir(async path => {
+      sha = await update(context, path, cloneUrl, pullRequest);
+    });
 
-  await merge(context, pullRequest, head);
+    await merge(context, pullRequest, sha);
+  } catch (error) {
+    if (error instanceof NeutralExitError) {
+      await merge(context, pullRequest, sha);
+      return;
+    }
+
+    throw error;
+  }
 }
 
 async function handleBranchUpdate(context, eventName, event) {

--- a/lib/common.js
+++ b/lib/common.js
@@ -104,5 +104,5 @@ module.exports = {
   logger,
   tmpdir,
   inspect,
-  retry
+  retry,
 };

--- a/lib/merge.js
+++ b/lib/merge.js
@@ -1,4 +1,4 @@
-const { NeutralExitError, logger, retry } = require("./common");
+const { logger, NeutralExitError, retry } = require("./common");
 
 const MAYBE_READY = ["clean", "has_hooks", "unknown", "unstable"];
 const NOT_READY = ["dirty", "draft"];
@@ -6,10 +6,20 @@ const NOT_READY = ["dirty", "draft"];
 const RETRY_SLEEP = 10000;
 
 async function merge(context, pullRequest, head) {
+  logger.info(`Merging PR #${pullRequest.number} ${pullRequest.title}`);
   const {
     octokit,
     config: { mergeMethod, commitMessageTemplate }
   } = context;
+  
+  const { mergeLabel } = context.config;
+  const prLabel = pullRequest.labels.find(({ name }) => name === mergeLabel);
+  const label = prLabel && prLabel.name;
+
+  if (label === undefined) {
+    logger.info("No matching labels found on PR, skipping");
+    throw new NeutralExitError();
+  }
 
   await waitUntilReady(octokit, pullRequest);
 

--- a/lib/update.js
+++ b/lib/update.js
@@ -12,8 +12,9 @@ async function update(context, dir, url, pullRequest) {
   }
 
   const { octokit, config } = context;
-  const { automerge, autorebase, mergeForks } = config;
-  const actions = [automerge, autorebase];
+  const { mergeForks, updateMethod, updateLabel } = config;
+  const prLabel = pullRequest.labels.find(({ name }) => name === updateLabel);
+  const label = prLabel && prLabel.name;
 
   if (pullRequest.head.repo.full_name !== pullRequest.base.repo.full_name) {
     if (!mergeForks) {
@@ -22,18 +23,7 @@ async function update(context, dir, url, pullRequest) {
     }
   }
 
-  let action = null;
-  for (const label of pullRequest.labels) {
-    if (actions.includes(label.name)) {
-      if (action === null) {
-        action = label.name;
-      } else {
-        throw new Error(`ambiguous labels: ${action} + ${label.name}`);
-      }
-    }
-  }
-
-  if (action === null) {
+  if (label === undefined) {
     logger.info("No matching labels found on PR, skipping");
     throw new NeutralExitError();
   }
@@ -42,12 +32,12 @@ async function update(context, dir, url, pullRequest) {
     throw new Error("invalid arguments!");
   }
 
-  if (action === automerge) {
+  if (updateMethod === 'merge') {
     return await merge(octokit, pullRequest);
-  } else if (action === autorebase) {
+  } else if (updateMethod === 'rebase') {
     return await rebase(dir, url, pullRequest);
   } else {
-    throw new Error(`invalid action: ${action}`);
+    throw new Error(`invalid update strategy: ${updateMethod}`);
   }
 }
 


### PR DESCRIPTION
## Changes

**Methods**
- `MERGE_METHOD`: Which method to use when merging the pull request (merge/rebase/squash), this is exactly the same as before
- `UPDATE_METHOD`: (new) Which method to use to update the pull request (merge/rebase)

**Labels**
- `MERGE_LABEL`: (new) When this label is assigned to a PR, it will be merged (using `MERGE_METHOD`) when it's ready
- `UPDATE_LABEL`: (new) When this label is assigned to a PR, it will be updated regularly (using `UPDATE_METHOD`)
- `UPDATE_AND_MERGE_LABEL`: (new) When this label is assigned to a PR, it will be updated regularly and merged when it's ready

## Defaults

**Methods**
- `MERGE_METHOD`: `merge` (as before)
- `UPDATE_METHOD`: `merge` same as Githubs default action

**Labels**
- `MERGE_LABEL`: "" (none)
- `UPDATE_LABEL`: "" (none)
- `UPDATE_AND_MERGE_LABEL`: `automerge`

Fix #16