### PR TITLE
Add "automerge" option to MERGE_COMMIT_MESSAGE

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ The following merge options are supported:
   default message), `pull-request-title` (use the pull request's title),
   `pull-request-description` (use the pull request's description),
   `pull-request-title-and-description` or a literal
-  value with optional placeholders (eg.: _Auto merge #{pullRequest.number}_).
+  value with optional placeholders (for example: _"Auto merge {pullRequest.number}"_).
   The default value is `automatic`.
 
 - `MERGE_FORKS`: Whether merging from external repositories is enabled

--- a/README.md
+++ b/README.md
@@ -90,8 +90,9 @@ The following merge options are supported:
   request into the base branch. Possible values are `automatic` (use GitHub's
   default message), `pull-request-title` (use the pull request's title),
   `pull-request-description` (use the pull request's description),
-  `pull-request-title-and-description` and
-  `automerge` (arbitrary '_Auto merge #{PR number}_'). The default value is `automatic`.
+  `pull-request-title-and-description` or a literal
+  value with optional placeholders (eg.: _Auto merge #{pullRequest.number}_).
+  The default value is `automatic`.
 
 - `MERGE_FORKS`: Whether merging from external repositories is enabled
   or not. By default, pull requests with branches from forked repositories will

--- a/README.md
+++ b/README.md
@@ -89,8 +89,9 @@ The following merge options are supported:
 - `MERGE_COMMIT_MESSAGE`: The commit message to use when merging the pull
   request into the base branch. Possible values are `automatic` (use GitHub's
   default message), `pull-request-title` (use the pull request's title),
-  `pull-request-description` (use the pull request's description), and
-  `pull-request-title-and-description`. The default value is `automatic`.
+  `pull-request-description` (use the pull request's description),
+  `pull-request-title-and-description` and
+  `automerge` (arbitrary '_Auto merge #{PR number}_'). The default value is `automatic`.
 
 - `MERGE_FORKS`: Whether merging from external repositories is enabled
   or not. By default, pull requests with branches from forked repositories will

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ The following merge options are supported:
   default message), `pull-request-title` (use the pull request's title),
   `pull-request-description` (use the pull request's description),
   `pull-request-title-and-description` or a literal
-  value with optional placeholders (for example: _"Auto merge {pullRequest.number}"_).
+  value with optional placeholders (for example `Auto merge {pullRequest.number}`).
   The default value is `automatic`.
 
 - `MERGE_FORKS`: Whether merging from external repositories is enabled

--- a/lib/merge.js
+++ b/lib/merge.js
@@ -160,7 +160,7 @@ function getCommitMessage(mergeCommitMessage, pullRequest) {
   } else if (mergeCommitMessage === "pull-request-title-and-description") {
     return pullRequest.title + "\n\n" + pullRequest.body;
   } else {
-    ;['number', 'title', 'body'].forEach(prProp => {
+    ["number", "title", "body"].forEach(prProp => {
       mergeCommitMessage.replace(new RegExp(`{pullRequest.${prProp}}`, 'g'), pullRequest[prProp]);
     });
     return mergeCommitMessage;

--- a/lib/merge.js
+++ b/lib/merge.js
@@ -160,7 +160,10 @@ function getCommitMessage(mergeCommitMessage, pullRequest) {
   } else if (mergeCommitMessage === "pull-request-title-and-description") {
     return pullRequest.title + "\n\n" + pullRequest.body;
   } else {
-    return mergeCommitMessage.replace(/{pullRequest.number}/g, pullRequest.number);
+    ;['number', 'title', 'body'].forEach(prProp => {
+      mergeCommitMessage.replace(new RegExp(`{pullRequest.${prProp}}`, 'g'), pullRequest[prProp]);
+    });
+    return mergeCommitMessage;
   }
 }
 

--- a/lib/merge.js
+++ b/lib/merge.js
@@ -159,10 +159,8 @@ function getCommitMessage(mergeCommitMessage, pullRequest) {
     return pullRequest.body;
   } else if (mergeCommitMessage === "pull-request-title-and-description") {
     return pullRequest.title + "\n\n" + pullRequest.body;
-  } else if (mergeCommitMessage === "automerge") {
-    return "Auto merge pull request #" + pullRequest.number;
   } else {
-    throw new Error(`unknown commit message value: ${mergeCommitMessage}`);
+    return mergeCommitMessage.replace(/{pullRequest.number}/g, pullRequest.number);
   }
 }
 

--- a/lib/merge.js
+++ b/lib/merge.js
@@ -159,6 +159,8 @@ function getCommitMessage(mergeCommitMessage, pullRequest) {
     return pullRequest.body;
   } else if (mergeCommitMessage === "pull-request-title-and-description") {
     return pullRequest.title + "\n\n" + pullRequest.body;
+  } else if (mergeCommitMessage === "automerge") {
+    return "Auto Merge (#" + pullRequest.number  + ")";
   } else {
     throw new Error(`unknown commit message value: ${mergeCommitMessage}`);
   }

--- a/lib/merge.js
+++ b/lib/merge.js
@@ -161,7 +161,10 @@ function getCommitMessage(mergeCommitMessage, pullRequest) {
     return pullRequest.title + "\n\n" + pullRequest.body;
   } else {
     ["number", "title", "body"].forEach(prProp => {
-      mergeCommitMessage = mergeCommitMessage.replace(new RegExp(`{pullRequest.${prProp}}`, 'g'), pullRequest[prProp]);
+      mergeCommitMessage = mergeCommitMessage.replace(
+        new RegExp(`{pullRequest.${prProp}}`, "g"),
+        pullRequest[prProp]
+      );
     });
     return mergeCommitMessage;
   }

--- a/lib/merge.js
+++ b/lib/merge.js
@@ -161,7 +161,7 @@ function getCommitMessage(mergeCommitMessage, pullRequest) {
     return pullRequest.title + "\n\n" + pullRequest.body;
   } else {
     ["number", "title", "body"].forEach(prProp => {
-      mergeCommitMessage.replace(new RegExp(`{pullRequest.${prProp}}`, 'g'), pullRequest[prProp]);
+      mergeCommitMessage = mergeCommitMessage.replace(new RegExp(`{pullRequest.${prProp}}`, 'g'), pullRequest[prProp]);
     });
     return mergeCommitMessage;
   }

--- a/lib/merge.js
+++ b/lib/merge.js
@@ -160,7 +160,7 @@ function getCommitMessage(mergeCommitMessage, pullRequest) {
   } else if (mergeCommitMessage === "pull-request-title-and-description") {
     return pullRequest.title + "\n\n" + pullRequest.body;
   } else if (mergeCommitMessage === "automerge") {
-    return "Auto Merge (#" + pullRequest.number  + ")";
+    return "Auto merge pull request #" + pullRequest.number;
   } else {
     throw new Error(`unknown commit message value: ${mergeCommitMessage}`);
   }


### PR DESCRIPTION
### What

I'm providing a way to ignore PR title/description on auto merge commit message.

### Why

I was having troubles to [skip ci] on Netlify preview for Dependabot updates, but not [skip ci] on PR merged to master.
Commit messages on PR have `[skip ci]`, but merge commit shouldn't have.

#### Working example (Proposal)

https://github.com/ecomclub/storefront/commit/978e3b10a2738b98af3c59b4c2e805108cab4f63

#### Not working example (Current)

https://github.com/ecomclub/storefront/commit/de8ab04181654a78bba82c1bf86d56a1c77f78f8

> I've tried with _MERGE_METHOD_ squash and merge, and _MERGE_COMMIT_MESSAGE_ automatic, pull-request-title and pull-request-description, always ending with a [skip ci] somewhere on merge commit message :disappointed: 