### PR TITLE
[DOCS] Only run automerge job within PRs

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ on:
 jobs:
   automerge:
     runs-on: ubuntu-latest
+    if: github.base_ref != null
     steps:
       - name: automerge
         uses: "pascalgn/automerge-action@7854d3bd607dccdaf0b2c134b699a812c8960213"


### PR DESCRIPTION
This might be helpful for everyone who has CI/CD jobs configured to run when something is pushed to branches. 

In our case, we executed tests and ran codecoverage checks after a PR has been merged. These builds triggered the workflow multiple times, because the `status` event was sent for the merge-commits on `develop`. These executions are not necessary and only consume superfluous minutes from the Actions quota, because they can't merge anything due to the fact that they are not triggered from a PR.

According to the [GitHub Actions Documentation](https://help.github.com/en/actions/automating-your-workflow-with-github-actions/contexts-and-expression-syntax-for-github-actions#github-context), the `github.base_ref` will be only be present if the action is triggered from a PR. To avoid the unnecessary executions of the action, we added the condition that can be seen in the file diff to our workflow definition.

The result will look like this:

![Screen Shot 2020-02-04 at 16 15 19](https://user-images.githubusercontent.com/7734806/73757458-8d8a2300-4769-11ea-931b-e3590981fabf.png)
