### PR TITLE
feat: add `MERGE_COMMIT_MESSAGE_REGEX` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,14 @@ The following merge options are supported:
   value with optional placeholders (for example `Auto merge {pullRequest.number}`).
   The default value is `automatic`.
 
+- `MERGE_COMMIT_MESSAGE_REGEX`: When using a commit message containing the
+  PR's body, use the first capturing subgroup from this regex as the commit
+  message. Can be used to separate content that should go with the commit into
+  the code base's history from boilerplate associated with the PR (licensing
+  notices, check lists, etc). For example, `(.*)^---` would keep everything up
+  until the first 3-dash line (horizontal rule in MarkDown) from the commit
+  message. The default value is empty, which disables this feature.
+
 - `MERGE_FORKS`: Whether merging from external repositories is enabled
   or not. By default, pull requests with branches from forked repositories will
   be merged the same way as pull requests with branches from the main
@@ -134,7 +142,7 @@ The following update options are supported:
   to the base branch. Possible values are `merge` (create a merge commit) or
   `rebase` (rebase the branch onto the head of the base branch). The default
   option is `merge`.
-  
+
   When the option is `rebase` and the [rebasing](https://git-scm.com/book/en/v2/Git-Branching-Rebasing)
   failed, the action will exit with error code 1. This will also be visible
   in the pull request page, with a message like "this branch has conflicts

--- a/lib/common.js
+++ b/lib/common.js
@@ -94,6 +94,7 @@ function createConfig(env = {}) {
   const mergeMethod = env.MERGE_METHOD || "merge";
   const mergeForks = env.MERGE_FORKS !== "false";
   const mergeCommitMessage = env.MERGE_COMMIT_MESSAGE || "automatic";
+  const mergeCommitMessageRegex = env.MERGE_COMMIT_MESSAGE_REGEX || '';
   const mergeRetries = parsePositiveInt("MERGE_RETRIES", 6);
   const mergeRetrySleep = parsePositiveInt("MERGE_RETRY_SLEEP", 10000);
   const mergeDeleteBranch = env.MERGE_DELETE_BRANCH === "true";
@@ -107,6 +108,7 @@ function createConfig(env = {}) {
     mergeMethod,
     mergeForks,
     mergeCommitMessage,
+    mergeCommitMessageRegex,
     mergeRetries,
     mergeRetrySleep,
     mergeDeleteBranch,

--- a/lib/merge.js
+++ b/lib/merge.js
@@ -19,6 +19,7 @@ async function merge(context, pullRequest) {
     config: {
       mergeMethod,
       mergeCommitMessage,
+      mergeCommitMessageRegex,
       mergeRemoveLabels,
       mergeRetries,
       mergeRetrySleep
@@ -33,6 +34,17 @@ async function merge(context, pullRequest) {
   );
   if (!ready) {
     return false;
+  }
+
+  if (mergeCommitMessageRegex) {
+    // If we find the regex, use the first capturing subgroup as new body (discarding whitespace).
+    const m = new RegExp(mergeCommitMessageRegex, 'sm').exec(pullRequest.body);
+    if (m) {
+      if (m[1] === undefined) {
+        throw new Error(`MERGE_COMMIT_MESSAGE_REGEX must contain a capturing subgroup: '${mergeCommitMessageRegex}'`);
+      }
+      pullRequest.body = m[1].trim();
+    }
   }
 
   const commitMessage = getCommitMessage(mergeCommitMessage, pullRequest);

--- a/test/common.test.js
+++ b/test/common.test.js
@@ -14,13 +14,18 @@ test("createConfig", () => {
     },
     mergeForks: true,
     mergeCommitMessage: "automatic",
+    mergeCommitMessageRegex: "",
+    mergeDeleteBranch: false,
     mergeRetries: 3,
     mergeRetrySleep: 10000,
     updateMethod: "merge",
     updateLabels: {
       blocking: ["block1", "block2"],
       required: ["required1", "required2"]
-    }
+    },
+    mergeRemoveLabels: [
+      "",
+    ],
   };
   expect(config).toEqual(expected);
 });

--- a/test/merge.test.js
+++ b/test/merge.test.js
@@ -1,0 +1,54 @@
+const { merge } = require("../lib/merge");
+const { logger, createConfig } = require("../lib/common");
+const { pullRequest } = require("./common");
+
+let octokit;
+
+beforeEach(() => {
+  octokit = {
+    pulls: {
+      merge: jest.fn()
+    }
+  };
+});
+
+test("MERGE_COMMIT_MESSAGE_REGEX can be used to cut PR body", async () => {
+  // GIVEN
+  const pr = pullRequest();
+  pr.body = [
+    'PSA: This is the meaty part of the PR body.',
+    'It also matches newlines.',
+    '',
+    '----',
+    '',
+    'Here is a silly license agreement.',
+  ].join('\n');
+
+  const config = createConfig({
+    MERGE_COMMIT_MESSAGE: 'pull-request-title-and-description',
+    MERGE_COMMIT_MESSAGE_REGEX: "PSA:(.*)^----"
+  });
+
+  // WHEN
+  expect(await merge({ config, octokit }, pr)).toEqual(true);
+
+  // THEN
+  expect(octokit.pulls.merge).toHaveBeenCalledWith(expect.objectContaining({
+    "commit_message": 'Update README\n\nThis is the meaty part of the PR body.\nIt also matches newlines.',
+    "pull_number": 1,
+    "repo": "repository",
+    "sha": "2c3b4d5",
+  }));
+});
+
+test("Throw if MERGE_COMMIT_MESSAGE_REGEX is invalid", async () => {
+  // GIVEN
+  const pr = pullRequest();
+  const config = createConfig({
+    MERGE_COMMIT_MESSAGE: 'pull-request-title-and-description',
+    MERGE_COMMIT_MESSAGE_REGEX: ".*"
+  });
+
+  // WHEN
+  expect(merge({ config, octokit }, pr)).rejects.toThrow('capturing subgroup');
+});


### PR DESCRIPTION
Can be used to prevent boilerplate parts of the PR message from making
itself into the commit history of the project (and potentially
subsequently polluting the CHANGELOG when using conventional commits).

Motivation: we have a project with a PR template that ends in a
licensing agreement. We squash-merge PRs to `master` and then use
`conventional-commits` to automatically generate a CHANGELOG from the
commits. I don't want the licensing footer to end up in the commit
message, since:

1) It has no business there; and
2) If the commit contains the term 'BREAKING CHANGE', everything
following that text will be copied into the changelog, including
the licensing footer.

This feature allows us to clean up our commit history.