### PR TITLE
Required reviews before merge

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -86,7 +86,8 @@ async function handlePullRequestUpdate(context, eventName, event) {
   }
 
   await update(context, event.pull_request);
-  await merge(context, event.pull_request);
+  const reviews = await getReviewsOrEmptyArray(context, event.pull_request.number);
+  await merge(context, event.pull_request, reviews);
 }
 
 async function handleCheckUpdate(context, eventName, event) {
@@ -107,7 +108,8 @@ async function handleCheckUpdate(context, eventName, event) {
         logger.trace("PR:", pullRequest);
 
         await update(context, pullRequest);
-        await merge(context, pullRequest);
+        const reviews = await getReviewsOrEmptyArray(context, pullRequest.number);
+        await merge(context, pullRequest, reviews);
       } else {
         const branchName = payload.head_branch;
         if (branchName != null) {
@@ -127,7 +129,8 @@ async function handlePullRequestReviewUpdate(context, eventName, event) {
   if (action === "submitted") {
     if (review.state === "approved") {
       await update(context, event.pull_request);
-      await merge(context, event.pull_request);
+      const reviews = await getReviewsOrEmptyArray(context, event.pull_request.number);
+      await merge(context, event.pull_request, reviews);
     } else {
       logger.info("Review state is not approved:", review.state);
       logger.info("Action ignored:", eventName, action);
@@ -173,7 +176,8 @@ async function checkPullRequestsForBranches(context, event, branchName) {
   for (const pullRequest of pullRequests) {
     try {
       await update(context, pullRequest);
-      await merge(context, pullRequest);
+      const reviews = await getReviewsOrEmptyArray(context, pullRequest.number);
+      await merge(context, pullRequest, reviews);
       ++updated;
     } catch (e) {
       logger.error(e);
@@ -261,7 +265,8 @@ async function handleScheduleTrigger(context) {
   for (const pullRequest of pullRequests) {
     try {
       await update(context, pullRequest);
-      await merge(context, pullRequest);
+      const reviews = await getReviewsOrEmptyArray(context, pullRequest.number);
+      await merge(context, pullRequest, reviews);
       ++updated;
     } catch (e) {
       logger.error(e);
@@ -292,11 +297,33 @@ async function handleIssueComment(context, eventName, event) {
       logger.trace("Full PR:", pullRequest);
 
       await update(context, pullRequest);
-      await merge(context, pullRequest);
+      const reviews = await getReviewsOrEmptyArray(context, pullRequest.number);
+      await merge(context, pullRequest, reviews);
     }
   } else {
     logger.info("Action ignored:", eventName, action);
   }
+}
+
+async function getReviewsOrEmptyArray(context, pullRequestNumber) {
+  const { config: { mergeAproovedByReviewers } } = context;
+  if (mergeAproovedByReviewers.length <= 0) {
+    return [];
+  }
+
+  const result =  await fetchPullRequestReviews(context, pullRequestNumber);
+  return result.data;
+}
+
+async function fetchPullRequestReviews({ octokit }, pullRequestNumber) {
+  const { GITHUB_REPOSITORY } = process.env;
+  const [owner, repo] = (GITHUB_REPOSITORY || "").split("/", 2);
+
+  return await octokit.pulls.listReviews({
+    owner,
+    repo,
+    pull_number: pullRequestNumber,
+  });
 }
 
 module.exports = { executeLocally, executeGitHubAction };

--- a/lib/common.js
+++ b/lib/common.js
@@ -94,6 +94,7 @@ function createConfig(env = {}) {
   const mergeCommitMessage = env.MERGE_COMMIT_MESSAGE || "automatic";
   const mergeCommitMessageRegex = env.MERGE_COMMIT_MESSAGE_REGEX || "";
   const mergeFilterAuthor = env.MERGE_FILTER_AUTHOR || "";
+  const mergeAproovedByReviewers = env.MERGE_APROOVED_BY_REVIEWERS || [];
   const mergeRetries = parsePositiveInt("MERGE_RETRIES", 6);
   const mergeRetrySleep = parsePositiveInt("MERGE_RETRY_SLEEP", 5000);
   const mergeDeleteBranch = env.MERGE_DELETE_BRANCH === "true";
@@ -111,6 +112,7 @@ function createConfig(env = {}) {
     mergeCommitMessage,
     mergeCommitMessageRegex,
     mergeFilterAuthor,
+    mergeAproovedByReviewers,
     mergeRetries,
     mergeRetrySleep,
     mergeDeleteBranch,

--- a/lib/common.js
+++ b/lib/common.js
@@ -69,6 +69,10 @@ function createConfig(env = {}) {
     };
   }
 
+  function parseMergeAproovedByReviewers(requiredReviewrs) {
+    return requiredReviewrs ? requiredReviewrs.split(",").map(s => s.trim()) : [];
+  }
+
   function parseMergeRemoveLabels(str, defaultValue) {
     return (str == null ? defaultValue : str).split(",").map(s => s.trim());
   }
@@ -94,7 +98,7 @@ function createConfig(env = {}) {
   const mergeCommitMessage = env.MERGE_COMMIT_MESSAGE || "automatic";
   const mergeCommitMessageRegex = env.MERGE_COMMIT_MESSAGE_REGEX || "";
   const mergeFilterAuthor = env.MERGE_FILTER_AUTHOR || "";
-  const mergeAproovedByReviewers = env.MERGE_APROOVED_BY_REVIEWERS || [];
+  const mergeAproovedByReviewers = parseMergeAproovedByReviewers(env.MERGE_APROOVED_BY_REVIEWERS);
   const mergeRetries = parsePositiveInt("MERGE_RETRIES", 6);
   const mergeRetrySleep = parsePositiveInt("MERGE_RETRY_SLEEP", 5000);
   const mergeDeleteBranch = env.MERGE_DELETE_BRANCH === "true";

--- a/lib/merge.js
+++ b/lib/merge.js
@@ -184,15 +184,9 @@ function skipPullRequest(context, pullRequest, reviews) {
     }
   }
 
-  for (const requiredReviewer of mergeAproovedByReviewers) {
-    if (reviews.some(review => review.user.login.toLowerCase() === requiredReviewer.toLowerCase() && review.state == "APPROVED")){
-      skip = false;
-      logger.info("Found required approve by a reviewer:", requiredReviewer);
-      break;
-    } else {
-      skip = true;
-      logger.info("Approve was not found for a reviewer:", requiredReviewer);
-    }
+  const reviewer = mergeAproovedByReviewers.find(requiredReviewer => reviews.some(review => review.user.login.toLowerCase() === requiredReviewer.toLowerCase() && review.state == "APPROVED"));
+  if (mergeAproovedByReviewers.length > 0 && !reviewer) {
+    skip = true;
   }
 
   return skip;

--- a/lib/merge.js
+++ b/lib/merge.js
@@ -186,6 +186,7 @@ function skipPullRequest(context, pullRequest, reviews) {
 
   for (const requiredReviewer of mergeAproovedByReviewers) {
     if (reviews.some(review => review.user.login.toLowerCase() === requiredReviewer.toLowerCase() && review.state == "APPROVED")){
+      skip = false;
       logger.info("Found required approve by a reviewer:", requiredReviewer);
       break;
     } else {

--- a/lib/merge.js
+++ b/lib/merge.js
@@ -3,8 +3,8 @@ const { logger, retry } = require("./common");
 const MAYBE_READY = ["clean", "has_hooks", "unknown", "unstable"];
 const NOT_READY = ["dirty", "draft"];
 
-async function merge(context, pullRequest) {
-  if (skipPullRequest(context, pullRequest)) {
+async function merge(context, pullRequest, reviews = []) {
+  if (skipPullRequest(context, pullRequest, reviews)) {
     return false;
   }
 
@@ -144,9 +144,9 @@ async function deleteBranch(octokit, pullRequest) {
   }
 }
 
-function skipPullRequest(context, pullRequest) {
+function skipPullRequest(context, pullRequest, reviews) {
   const {
-    config: { mergeForks, mergeLabels }
+    config: { mergeForks, mergeLabels, mergeAproovedByReviewers }
   } = context;
 
   let skip = false;
@@ -181,6 +181,16 @@ function skipPullRequest(context, pullRequest) {
     if (!labels.includes(required)) {
       logger.info("Skipping PR merge, required label missing:", required);
       skip = true;
+    }
+  }
+
+  for (const requiredReviewer of mergeAproovedByReviewers) {
+    if (reviews.some(review => review.user.login.toLowerCase() === requiredReviewer.toLowerCase() && review.state == "APPROVED")){
+      logger.info("Found required approve by a reviewer:", requiredReviewer);
+      break;
+    } else {
+      skip = true;
+      logger.info("Approve was not found for a reviewer:", requiredReviewer);
     }
   }
 

--- a/test/common.js
+++ b/test/common.js
@@ -34,4 +34,25 @@ function pullRequest() {
   };
 }
 
-module.exports = { pullRequest };
+function reviews() {
+  return [
+    {
+      id: 80,
+      user: {
+        "login": "minime",
+      },
+      body: "Here is the body for the review.",
+      state: "APPROVED",
+    },
+    {
+      id: 81,
+      user: {
+        "login": "minime2",
+      },
+      body: "Here is the body for the review.",
+      state: "APPROVED",
+    }
+  ];
+}
+
+module.exports = { pullRequest, reviews };

--- a/test/common.test.js
+++ b/test/common.test.js
@@ -9,6 +9,7 @@ test("createConfig", () => {
   const expected = {
     mergeMethod: "merge",
     mergeFilterAuthor: "",
+    mergeAproovedByReviewers: [],
     mergeLabels: {
       blocking: [],
       required: []

--- a/test/merge.test.js
+++ b/test/merge.test.js
@@ -1,6 +1,6 @@
 const { merge } = require("../lib/merge");
 const { createConfig } = require("../lib/common");
-const { pullRequest } = require("./common");
+const { pullRequest, reviews } = require("./common");
 
 let octokit;
 
@@ -73,6 +73,28 @@ test("MERGE_FILTER_AUTHOR can be used to auto merge based on author", async () =
 
   // WHEN
   expect(await merge({ config, octokit }, pr)).toEqual(true);
+});
+
+test("MERGE_APROOVED_BY_REVIEWERS can be used to auto merge based on requested reviewers", async () => {
+  // GIVEN
+  const pr = pullRequest();
+  const reviewsMock = reviews();
+  const reviewers = ["minime"];
+
+  const config = createConfig({
+    MERGE_APROOVED_BY_REVIEWERS: reviewers,
+  });
+
+  // WHEN
+  expect(await merge({ config, octokit }, pr, reviewsMock)).toEqual(true);
+
+  // GIVEN
+  const configWithNotApprovedReviwers = createConfig({
+    MERGE_APROOVED_BY_REVIEWERS: ["minime_fake"],
+  });
+
+  // WHEN
+  expect(await merge({ config: configWithNotApprovedReviwers, octokit }, pr, reviewsMock)).toEqual(false);
 });
 
 test("MERGE_FILTER_AUTHOR when not set should not affect anything", async () => {

--- a/test/merge.test.js
+++ b/test/merge.test.js
@@ -79,7 +79,7 @@ test("MERGE_APROOVED_BY_REVIEWERS can be used to auto merge based on requested r
   // GIVEN
   const pr = pullRequest();
   const reviewsMock = reviews();
-  const reviewers = ["minime"];
+  const reviewers = "minime";
 
   const config = createConfig({
     MERGE_APROOVED_BY_REVIEWERS: reviewers,
@@ -90,7 +90,7 @@ test("MERGE_APROOVED_BY_REVIEWERS can be used to auto merge based on requested r
 
   // GIVEN
   const configWithNotApprovedReviwers = createConfig({
-    MERGE_APROOVED_BY_REVIEWERS: ["minime_fake"],
+    MERGE_APROOVED_BY_REVIEWERS: "minime_fake",
   });
 
   // WHEN

--- a/test/merge.test.js
+++ b/test/merge.test.js
@@ -79,7 +79,7 @@ test("MERGE_APROOVED_BY_REVIEWERS can be used to auto merge based on requested r
   // GIVEN
   const pr = pullRequest();
   const reviewsMock = reviews();
-  const reviewers = "minime";
+  const reviewers = "test, minime";
 
   const config = createConfig({
     MERGE_APROOVED_BY_REVIEWERS: reviewers,
@@ -90,11 +90,26 @@ test("MERGE_APROOVED_BY_REVIEWERS can be used to auto merge based on requested r
 
   // GIVEN
   const configWithNotApprovedReviwers = createConfig({
-    MERGE_APROOVED_BY_REVIEWERS: "minime_fake",
+    MERGE_APROOVED_BY_REVIEWERS: "minime_fake, test, fake",
   });
 
   // WHEN
   expect(await merge({ config: configWithNotApprovedReviwers, octokit }, pr, reviewsMock)).toEqual(false);
+});
+
+test("MERGE_APROOVED_BY_REVIEWERS doesn't affect other checks", async () => {
+  // GIVEN
+  const pr = pullRequest();
+  const reviewsMock = reviews();
+  const reviewers = "test, minime, test2";
+
+  const config = createConfig({
+    MERGE_LABELS: 'SHOULD_FAIL',
+    MERGE_APROOVED_BY_REVIEWERS: reviewers,
+  });
+
+  // WHEN
+  expect(await merge({ config, octokit }, pr, reviewsMock)).toEqual(false);
 });
 
 test("MERGE_FILTER_AUTHOR when not set should not affect anything", async () => {


### PR DESCRIPTION
Hey guys, we at Mews decided to use this library to enable some automation in our review flow. We missed one functionality which was an approve by the codeowner before PR can get merged.

In this PR I added this functionality trying to follow the same code style you used and covered it with tests. It is also breaking change free.

I'd also like to explain why this functionally is important for us. In GitHub settings it is allowed to enforce different rules so the branch can get merged. We have a list of codeowners at this moment and only those people have rights to merge something into the master branch. However, allowing to use `automerge` label will basically make the merge possible for everyone in the repository without code owner consent. Of course, there is functionality in branch protection rules called `Require review from Code Owners`, however, this functionality uses `CODEOWNERS` file, which in our set up is being used differently, to automatically assign reviews to people based on the code which was touched. I belive this can help not only us but many other people using this awesome action. Looking forward to your review. Thanks!