### PR TITLE
Add MERGE_COMMIT_MESSAGE_EXCLUDE_REGEX option

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,11 @@ The following merge options are supported:
   until the first 3-dash line (horizontal rule in MarkDown) from the commit
   message. The default value is empty, which disables this feature.
 
+- `MERGE_COMMIT_MESSAGE_EXCLUDE_REGEX`: When using a commit message containing the
+  PR's body, use this regex to strip out unwanted content.  For example, to strip html
+  comments, so the commit message matches the rendered PR description use the regex
+  `<!--[\\s\\S]*?(?:-->)?<!---+>?|<!(?![dD][oO][cC][tT][yY][pP][eE]|\\[CDATA\\[)[^>]*>?|<[?][^>]*>?`
+
 - `MERGE_FILTER_AUTHOR`: When set, only pull requests raised by this author
   will be merged automatically.
 

--- a/lib/common.js
+++ b/lib/common.js
@@ -93,6 +93,7 @@ function createConfig(env = {}) {
   const mergeForks = env.MERGE_FORKS !== "false";
   const mergeCommitMessage = env.MERGE_COMMIT_MESSAGE || "automatic";
   const mergeCommitMessageRegex = env.MERGE_COMMIT_MESSAGE_REGEX || "";
+  const mergeCommitMessageExcludeRegex = env.MERGE_COMMIT_MESSAGE_EXCLUDE_REGEX || "";
   const mergeFilterAuthor = env.MERGE_FILTER_AUTHOR || "";
   const mergeRetries = parsePositiveInt("MERGE_RETRIES", 6);
   const mergeRetrySleep = parsePositiveInt("MERGE_RETRY_SLEEP", 5000);
@@ -110,6 +111,7 @@ function createConfig(env = {}) {
     mergeForks,
     mergeCommitMessage,
     mergeCommitMessageRegex,
+    mergeCommitMessageExcludeRegex,
     mergeFilterAuthor,
     mergeRetries,
     mergeRetrySleep,

--- a/lib/merge.js
+++ b/lib/merge.js
@@ -20,6 +20,7 @@ async function merge(context, pullRequest) {
       mergeMethod,
       mergeCommitMessage,
       mergeCommitMessageRegex,
+      mergeCommitMessageExcludeRegex,
       mergeFilterAuthor,
       mergeRemoveLabels,
       mergeRetries,
@@ -48,6 +49,11 @@ async function merge(context, pullRequest) {
       }
       pullRequest.body = m[1].trim();
     }
+  }
+
+  if (mergeCommitMessageExcludeRegex) {
+    // If we find the regex, use it to transform the PR body.
+    pullRequest.body = pullRequest.body.replace(new RegExp(mergeCommitMessageExcludeRegex, "g"), "").trim();
   }
 
   if (mergeFilterAuthor && pullRequest.user.login !== mergeFilterAuthor) {

--- a/test/merge.test.js
+++ b/test/merge.test.js
@@ -57,6 +57,41 @@ test("Throw if MERGE_COMMIT_MESSAGE_REGEX is invalid", async () => {
   expect(merge({ config, octokit }, pr)).rejects.toThrow("capturing subgroup");
 });
 
+test("MERGE_COMMIT_MESSAGE_EXCLUDE_REGEX can be used to transform PR body", async () => {
+  // GIVEN
+  const pr = pullRequest();
+  pr.body = [
+    "PSA: This is the meaty part of the PR body.",
+    "It also matches newlines.",
+    "",
+    "<!-- Please don't render my -->",
+    "this is important",
+    "<!-- comments, even if they are",
+    "multiline -->",
+    "This is also important"
+  ].join("\n");
+
+  const config = createConfig({
+    MERGE_COMMIT_MESSAGE: "pull-request-title-and-description",
+    MERGE_COMMIT_MESSAGE_EXCLUDE_REGEX: "<!--[\\s\\S]*?(?:-->)?<!---+>?|<!(?![dD][oO][cC][tT][yY][pP][eE]|\\[CDATA\\[)[^>]*>?|<[?][^>]*>?"
+  });
+
+  // WHEN
+  expect(await merge({ config, octokit }, pr)).toEqual(true);
+
+  // THEN
+  expect(octokit.pulls.merge).toHaveBeenCalledWith(
+    expect.objectContaining({
+      commit_title:
+        "Update README\n\nPSA: This is the meaty part of the PR body.\nIt also matches newlines.\n\n\nthis is important\n\nThis is also important",
+      commit_message: "",
+      pull_number: 1,
+      repo: "repository",
+      sha: "2c3b4d5"
+    })
+  );
+});
+
 test("MERGE_FILTER_AUTHOR can be used to auto merge based on author", async () => {
   // GIVEN
   const pr = pullRequest();


### PR DESCRIPTION
Add MERGE_COMMIT_MESSAGE_EXCLUDE_REGEX to specify a regex to filter the PR body; example
usage is to filter HTML comments so the commit message matches the rendered description in
the github UI.