### PR TITLE
Add support for pull_request_target event

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -63,7 +63,7 @@ async function executeGitHubAction(context, eventName, eventData) {
     await handleBranchUpdate(context, eventName, eventData);
   } else if (eventName === "status") {
     await handleStatusUpdate(context, eventName, eventData);
-  } else if (eventName === "pull_request") {
+  } else if (eventName === "pull_request" || eventName === "pull_request_target") {
     await handlePullRequestUpdate(context, eventName, eventData);
   } else if (eventName === "check_suite" || eventName === "check_run") {
     await handleCheckUpdate(context, eventName, eventData);


### PR DESCRIPTION
The pull_request_target event is useful for forks as it will use the upstream repositories workflow file and GitHub will give it a read/write access token.

More info for the event can be found in this blog post by GitHub -- https://github.blog/2020-08-03-github-actions-improvements-for-fork-and-pull-request-workflows/