### PR TITLE
remove link to closed issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,9 +209,6 @@ You can configure the environment variables in the workflow file like this:
   Similarly, when another GitHub workflow creates a pull request, this action will not be triggered.
   This is because [an action in a workflow run can't trigger a new workflow run](https://help.github.com/en/actions/automating-your-workflow-with-github-actions/events-that-trigger-workflows).
 - When [using a personal access token (PAT) to work around the above limitation](https://help.github.com/en/actions/reference/events-that-trigger-workflows#triggering-new-workflows-using-a-personal-access-token), note that when the user issuing the PAT is an administrator and [branch restrictions do not include administrators](https://help.github.com/en/github/administering-a-repository/enabling-branch-restrictions), pull requests may be merged even if they are not mergeable for non-administrators (see [#65](https://github.com/pascalgn/automerge-action/issues/65)).
-- When a check from a build tools like Jenkins or CircleCI completes, GitHub
-  triggers the action workflow, but sometimes the pull request state is still
-  pending, blocking the merge. This is [an open issue](https://github.com/pascalgn/automerge-action/issues/7).
 - Currently, there is no way to trigger workflows when the pull request branch
   becomes out of date with the base branch. There is a request in the
   [GitHub community forum](https://github.community/t5/GitHub-Actions/New-Trigger-is-mergable-state/m-p/36908).


### PR DESCRIPTION
Looks like https://github.com/pascalgn/automerge-action/issues/7 is closed now so this is no longer an issue?