### PR TITLE
Handle check_suite/check_run from forks

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -119,17 +119,11 @@ async function handleCheckUpdate(context, eventName, event) {
         if (branchName != null) {
           await checkPullRequestsForBranches(context, event, branchName);
         } else {
-          const foundPR = await checkPullRequestsForHeadSha(
+          await checkPullRequestsForHeadSha(
             context,
             event.repository,
             payload.head_sha
           );
-          if (!foundPR) {
-            logger.info(
-              "Could not find branch name in this status check result" +
-                " or corresponding PR from a forked repository"
-            );
-          }
         }
       }
     } else {
@@ -237,7 +231,12 @@ async function checkPullRequestsForHeadSha(context, repo, head_sha) {
   if (updated === 0) {
     logger.info("No PRs have been updated/merged");
   }
-  return foundPR;
+  if (!foundPR) {
+    logger.info(
+      "Could not find branch name in this status check result" +
+        " or corresponding PR from a forked repository"
+    );
+  }
 }
 
 async function handleBranchUpdate(context, eventName, event) {

--- a/lib/api.js
+++ b/lib/api.js
@@ -119,7 +119,17 @@ async function handleCheckUpdate(context, eventName, event) {
         if (branchName != null) {
           await checkPullRequestsForBranches(context, event, branchName);
         } else {
-          logger.info("Could not find branch name in this status check result");
+          const foundPR = await checkPullRequestsForHeadSha(
+            context,
+            event.repository,
+            payload.head_sha
+          );
+          if (!foundPR) {
+            logger.info(
+              "Could not find branch name in this status check result" +
+                " or corresponding PR from a forked repository"
+            );
+          }
         }
       }
     } else {
@@ -194,6 +204,40 @@ async function checkPullRequestsForBranches(context, event, branchName) {
   if (updated === 0) {
     logger.info("No PRs have been updated/merged");
   }
+}
+
+async function checkPullRequestsForHeadSha(context, repo, head_sha) {
+  const { octokit } = context;
+  logger.debug("Listing pull requests to look for", head_sha, "...");
+  const { data: pullRequests } = await octokit.pulls.list({
+    owner: repo.owner.login,
+    repo: repo.name,
+    state: "open",
+    sort: "updated",
+    direction: "desc",
+    per_page: MAX_PR_COUNT
+  });
+
+  let updated = 0;
+  let foundPR = false;
+  for (const pullRequest of pullRequests) {
+    if (pullRequest.head.sha !== head_sha) {
+      continue;
+    }
+    foundPR = true;
+    try {
+      await update(context, pullRequest);
+      await merge(context, pullRequest);
+      ++updated;
+    } catch (e) {
+      logger.error(e);
+    }
+  }
+
+  if (updated === 0) {
+    logger.info("No PRs have been updated/merged");
+  }
+  return foundPR;
 }
 
 async function handleBranchUpdate(context, eventName, event) {

--- a/test/api.test.js
+++ b/test/api.test.js
@@ -1,0 +1,33 @@
+const api = require("../lib/api");
+const { createConfig } = require("../lib/common");
+const { pullRequest } = require("./common");
+
+let octokit;
+
+test("forked PR check_suite/check_run updates are handled", async () => {
+  // GIVEN
+  const head_sha = "1234abcd";
+  const pr = pullRequest();
+  pr.labels = [{ name: "automerge" }];
+  pr.head.sha = head_sha;
+
+  const config = createConfig({});
+
+  let merged = false;
+  octokit = {
+    pulls: {
+      list: jest.fn(() => ({ data: [pr] })),
+      merge: jest.fn(() => (merged = true))
+    }
+  };
+
+  const event = {
+    action: "completed",
+    repository: { owner: { login: "other-username" }, name: "repository" },
+    check_suite: { conclusion: "success", head_sha, pull_requests: [] }
+  };
+
+  // WHEN
+  await api.executeGitHubAction({ config, octokit }, "check_suite", event);
+  expect(merged).toEqual(true);
+});


### PR DESCRIPTION
Right now, PRs from forks can't trigger the action because [`head_branch` is `null` for forks](https://docs.github.com/en/developers/webhooks-and-events/webhook-events-and-payloads#check_run).
This PR works around that by searching open PRs for the same `head_sha`.
See #46.