### PR TITLE
Add support for workflow_dispatch event

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -59,17 +59,17 @@ async function executeGitHubAction(context, eventName, eventData) {
   logger.info("Event name:", eventName);
   logger.trace("Event data:", eventData);
 
-  if (eventName === "push") {
+  if (["push", "workflow_dispatch"].includes(eventName)) {
     await handleBranchUpdate(context, eventName, eventData);
   } else if (eventName === "status") {
     await handleStatusUpdate(context, eventName, eventData);
   } else if (eventName === "pull_request") {
     await handlePullRequestUpdate(context, eventName, eventData);
-  } else if (eventName === "check_suite" || eventName === "check_run") {
+  } else if (["check_suite", "check_run"].includes(eventName)) {
     await handleCheckUpdate(context, eventName, eventData);
   } else if (eventName === "pull_request_review") {
     await handlePullRequestReviewUpdate(context, eventName, eventData);
-  } else if (eventName === "schedule" || eventName === "repository_dispatch") {
+  } else if (["schedule", "repository_dispatch"].includes(eventName)) {
     await handleScheduleTriggerOrRepositoryDispatch(context);
   } else if (eventName === "issue_comment") {
     await handleIssueComment(context, eventName, eventData);


### PR DESCRIPTION
I would love to see support for running this workflow from the Actions tab. This could be useful for getting newcomers to trial the action without needing to think through all of the relevant triggering events. This is also useful for a subset of pull requests where I would want the retry behavior to kick in (eg. Dependabot and deploys or releases).

For some background on the `workflow_dispatch` event: https://docs.github.com/en/actions/configuring-and-managing-workflows/configuring-a-workflow#manually-running-a-workflow