### PR TITLE
Handle workflow_dispatch as intended

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,6 +203,24 @@ You can configure the environment variables in the workflow file like this:
           UPDATE_METHOD: "rebase"
 ```
 
+## Supported Events
+
+Automerge can be triggered by these webhook events:
+
+* `check_run`
+* `check_suite`
+* `issue_comment`
+* `pull_request_review`
+* `pull_request_target`
+* `pull_request`
+* `push`
+* `repository_dispatch`
+* `schedule`
+* `status`
+* `workflow_dispatch`
+
+For more information on when these occur, see the Github documentation on [Webhook events and payloads](https://docs.github.com/en/developers/webhooks-and-events/webhook-events-and-payloads).
+
 ## Limitations
 
 - When a pull request is merged by this action, the merge will not trigger other GitHub workflows.

--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ You can configure the environment variables in the workflow file like this:
 
 ## Supported Events
 
-Automerge can be triggered by these webhook events:
+Automerge can be configured to run for these events:
 
 * `check_run`
 * `check_suite`
@@ -219,7 +219,7 @@ Automerge can be triggered by these webhook events:
 * `status`
 * `workflow_dispatch`
 
-For more information on when these occur, see the Github documentation on [Webhook events and payloads](https://docs.github.com/en/developers/webhooks-and-events/webhook-events-and-payloads).
+For more information on when these occur, see the Github documentation on [events that trigger workflows](https://docs.github.com/en/actions/reference/events-that-trigger-workflows) and [their payloads](https://docs.github.com/en/developers/webhooks-and-events/webhook-events-and-payloads).
 
 ## Limitations
 

--- a/lib/api.js
+++ b/lib/api.js
@@ -60,7 +60,7 @@ async function executeGitHubAction(context, eventName, eventData) {
   logger.trace("Event data:", eventData);
 
   if (["push"].includes(eventName)) {
-    await handleBranchUpdate(context, eventName, eventData);
+    await handleBaseBranchUpdate(context, eventName, eventData);
   } else if (["status"].includes(eventName)) {
     await handleStatusUpdate(context, eventName, eventData);
   } else if (["pull_request", "pull_request_target"].includes(eventName)
@@ -199,7 +199,7 @@ async function checkPullRequestsForBranches(context, event, branchName) {
   }
 }
 
-async function handleBranchUpdate(context, eventName, event) {
+async function handleBaseBranchUpdate(context, eventName, event) {
   const { ref } = event;
   if (!ref.startsWith("refs/heads/")) {
     logger.info("Push does not reference a branch:", ref);

--- a/lib/api.js
+++ b/lib/api.js
@@ -3,6 +3,7 @@ const process = require("process");
 const { ClientError, logger } = require("./common");
 const { update } = require("./update");
 const { merge } = require("./merge");
+const { branchName } = require("./util");
 
 const URL_REGEXP = /^https:\/\/github.com\/([^/]+)\/([^/]+)\/(pull|tree)\/([^ ]+)$/;
 
@@ -201,12 +202,12 @@ async function checkPullRequestsForBranches(context, event, branchName) {
 
 async function handleBaseBranchUpdate(context, eventName, event) {
   const { ref } = event;
-  if (!ref.startsWith("refs/heads/")) {
+  const branch = branchName(ref);
+  if (!branch) {
     logger.info("Push does not reference a branch:", ref);
     return;
   }
 
-  const branch = ref.substr(11);
   logger.debug("Updated branch:", branch);
 
   const { octokit } = context;
@@ -251,7 +252,11 @@ async function handleBaseBranchUpdate(context, eventName, event) {
 
 async function handleWorkflowDispatch(context, eventName, event) {
   const { ref } = event;
-  const branch = ref.substr(11);
+  const branch = branchName(ref);
+  if (!branch) {
+    logger.info("Dispatch does not reference a branch:", ref);
+    return;
+  }
 
   await checkPullRequestsForBranches(context, event, branch);
 }

--- a/lib/api.js
+++ b/lib/api.js
@@ -59,23 +59,23 @@ async function executeGitHubAction(context, eventName, eventData) {
   logger.info("Event name:", eventName);
   logger.trace("Event data:", eventData);
 
-  if (["push", "workflow_dispatch"].includes(eventName)) {
+  if (["push"].includes(eventName)) {
     await handleBranchUpdate(context, eventName, eventData);
-  } else if (eventName === "status") {
+  } else if (["status"].includes(eventName)) {
     await handleStatusUpdate(context, eventName, eventData);
-  } else if (
-    eventName === "pull_request" ||
-    eventName === "pull_request_target"
+  } else if (["pull_request", "pull_request_target"].includes(eventName)
   ) {
     await handlePullRequestUpdate(context, eventName, eventData);
   } else if (["check_suite", "check_run"].includes(eventName)) {
     await handleCheckUpdate(context, eventName, eventData);
-  } else if (eventName === "pull_request_review") {
+  } else if (["pull_request_review"].includes(eventName)) {
     await handlePullRequestReviewUpdate(context, eventName, eventData);
   } else if (["schedule", "repository_dispatch"].includes(eventName)) {
     await handleScheduleTriggerOrRepositoryDispatch(context);
-  } else if (eventName === "issue_comment") {
+  } else if (["issue_comment"].includes(eventName)) {
     await handleIssueComment(context, eventName, eventData);
+  } else if (["workflow_dispatch"].includes(eventName)) {
+    await handleWorkflowDispatch(context, eventName, eventData);
   } else {
     throw new ClientError(`invalid event type: ${eventName}`);
   }
@@ -247,6 +247,13 @@ async function handleBranchUpdate(context, eventName, event) {
   } else {
     logger.info("No PRs based on", branch, "have been updated");
   }
+}
+
+async function handleWorkflowDispatch(context, eventName, event) {
+  const { ref } = event;
+  const branch = ref.substr(11);
+
+  await checkPullRequestsForBranches(context, event, branch);
 }
 
 async function handleScheduleTriggerOrRepositoryDispatch(context) {

--- a/lib/util.js
+++ b/lib/util.js
@@ -1,0 +1,8 @@
+function branchName(ref) {
+  const branchPrefix = "refs/heads/";
+  if (ref.startsWith(branchPrefix)) {
+    return ref.substr(branchPrefix.length);
+  }
+}
+
+module.exports = { branchName };

--- a/test/util.test.js
+++ b/test/util.test.js
@@ -1,0 +1,13 @@
+const { branchName } = require("../lib/util");
+
+describe("branchName", () => {
+  it("returns the branch name from a reference referring to a branch", async () => {
+    expect(branchName("refs/heads/main")).toEqual("main");
+    expect(branchName("refs/heads/features/branch_with_slashes")).toEqual("features/branch_with_slashes");
+  });
+
+  it("is falsey for other kinds of git references", async () => {
+    expect(branchName("refs/tags/v1.0")).toBeUndefined();
+    expect(branchName("refs/remotes/origin/main")).toBeUndefined();
+  });
+});


### PR DESCRIPTION
(Follow-up to https://github.com/pascalgn/automerge-action/pull/107)

🤦  In my original PR I grossly misunderstood what `handleBranchUpdate` was doing. The intended experience was this:

![Screen_Shot_2020-09-19_at_11_40_30](https://user-images.githubusercontent.com/1744567/93686767-628cdf00-fa6d-11ea-9756-ddedc85c6f8f.png)

Here is a way to reuse some existing parts to achieve this.
 