### PR TITLE
Support for more PR properties in MERGE_COMMIT_MESSAGE

### DIFF
--- a/lib/merge.js
+++ b/lib/merge.js
@@ -1,5 +1,5 @@
 const { logger, retry } = require("./common");
-var _ = require('lodash');
+const resolvePath = require('object-resolve-path');
 
 const MAYBE_READY = ["clean", "has_hooks", "unknown", "unstable"];
 const NOT_READY = ["dirty", "draft"];
@@ -330,7 +330,7 @@ function getCommitMessage(mergeCommitMessage, pullRequest) {
     propertiesToArray(pullRequest).forEach(prProp => {
       mergeCommitMessage = mergeCommitMessage.replace(
         new RegExp(`{pullRequest.${prProp}}`, "g"),
-          _.get(pullRequest, prProp)
+          resolvePath(pullRequest, prProp)
       );
     });
     return mergeCommitMessage;

--- a/lib/merge.js
+++ b/lib/merge.js
@@ -1,4 +1,5 @@
 const { logger, retry } = require("./common");
+var _ = require('lodash');
 
 const MAYBE_READY = ["clean", "has_hooks", "unknown", "unstable"];
 const NOT_READY = ["dirty", "draft"];
@@ -294,6 +295,28 @@ function getMergeMethod(defaultMergeMethod, mergeMethodLabels, pullRequest) {
   return defaultMergeMethod;
 }
 
+// https://stackoverflow.com/a/53620876
+function propertiesToArray(obj) {
+  const isObject = val =>
+      typeof val === 'object' && !Array.isArray(val);
+
+  const addDelimiter = (a, b) =>
+      a ? `${a}.${b}` : b;
+
+  const paths = (obj = {}, head = '') => {
+      return Object.entries(obj)
+          .reduce((product, [key, value]) => 
+              {
+                  let fullPath = addDelimiter(head, key)
+                  return isObject(value) ?
+                      product.concat(paths(value, fullPath))
+                  : product.concat(fullPath)
+              }, []);
+  }
+
+  return paths(obj);
+}
+
 function getCommitMessage(mergeCommitMessage, pullRequest) {
   if (mergeCommitMessage === "automatic") {
     return undefined;
@@ -304,10 +327,10 @@ function getCommitMessage(mergeCommitMessage, pullRequest) {
   } else if (mergeCommitMessage === "pull-request-title-and-description") {
     return pullRequest.title + "\n\n" + pullRequest.body;
   } else {
-    ["number", "title", "body"].forEach(prProp => {
+    propertiesToArray(pullRequest).forEach(prProp => {
       mergeCommitMessage = mergeCommitMessage.replace(
         new RegExp(`{pullRequest.${prProp}}`, "g"),
-        pullRequest[prProp]
+          _.get(pullRequest, prProp)
       );
     });
     return mergeCommitMessage;

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "@octokit/rest": "^18.0.6",
     "argparse": "^2.0.1",
     "fs-extra": "^9.0.1",
+    "object-resolve-path": "^1.1.1",
     "tmp": "^0.2.1"
   },
   "devDependencies": {

--- a/test/merge.test.js
+++ b/test/merge.test.js
@@ -13,6 +13,32 @@ beforeEach(() => {
   };
 });
 
+test("MERGE_COMMIT_MESSAGE with nested custom fields", async () => {
+  // GIVEN
+  const pr = pullRequest();
+  pr.title = "This is the PR's title"
+  pr.user = {login: "author"};
+
+  const config = createConfig({
+    MERGE_COMMIT_MESSAGE: "{pullRequest.title} @{pullRequest.user.login}",
+  });
+
+  // WHEN
+  expect(await merge({ config, octokit }, pr)).toEqual(true);
+
+  // THEN
+  expect(octokit.pulls.merge).toHaveBeenCalledWith(
+    expect.objectContaining({
+      commit_title:
+        "This is the PR's title @author",
+      commit_message: "",
+      pull_number: 1,
+      repo: "repository",
+      sha: "2c3b4d5"
+    })
+  );
+});
+
 test("MERGE_COMMIT_MESSAGE_REGEX can be used to cut PR body", async () => {
   // GIVEN
   const pr = pullRequest();


### PR DESCRIPTION
This PR hopefully fixes #111. It extends the customization capabilities of MERGE_COMMIT_MESSAGE by provinding access to all properties of a pullRequest object (and not only `title`, `body` and `number` as it is currently the case).