### PR TITLE
fix: update GitHub Action to run on nodejs16.

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1,7 +1,7 @@
 name: "Merge pull requests (automerge-action)"
 description: "Automatically merge pull requests that are ready"
 runs:
-  using: "node12"
+  using: "node16"
   main: "dist/index.js"
 branding:
   icon: "git-pull-request"


### PR DESCRIPTION
See https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/ for more details.