### PR TITLE
Allow for merge attempts with `blocked` state

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -1258,9 +1258,6 @@ function checkReady(pullRequest, context) {
 
 function mergeable(pullRequest) {
   const { mergeable_state } = pullRequest;
-  logger.info("mergeable_state: ", mergeable_state);
-  logger.info("MAYBE_READY: ", MAYBE_READY);
-  logger.info("MAYBE_READY.includes(mergeable_state): ", MAYBE_READY.includes(mergeable_state));
   if (mergeable_state == null || MAYBE_READY.includes(mergeable_state)) {
     logger.info("PR is probably ready: mergeable_state:", mergeable_state);
     return "success";

--- a/dist/index.js
+++ b/dist/index.js
@@ -983,7 +983,7 @@ const {
   retry
 } = __nccwpck_require__(6979);
 
-const MAYBE_READY = ["clean", "has_hooks", "unknown", "unstable"];
+const MAYBE_READY = ["clean", "has_hooks", "unknown", "unstable", "blocked"];
 const NOT_READY = ["dirty", "draft"];
 
 const PR_PROPERTY = new RegExp("{pullRequest.([^}]+)}", "g");
@@ -1258,6 +1258,9 @@ function checkReady(pullRequest, context) {
 
 function mergeable(pullRequest) {
   const { mergeable_state } = pullRequest;
+  logger.info("mergeable_state: ", mergeable_state);
+  logger.info("MAYBE_READY: ", MAYBE_READY);
+  logger.info("MAYBE_READY.includes(mergeable_state): ", MAYBE_READY.includes(mergeable_state));
   if (mergeable_state == null || MAYBE_READY.includes(mergeable_state)) {
     logger.info("PR is probably ready: mergeable_state:", mergeable_state);
     return "success";
@@ -23227,7 +23230,7 @@ module.exports = JSON.parse('[[[0,44],"disallowed_STD3_valid"],[[45,46],"valid"]
 /***/ ((module) => {
 
 "use strict";
-module.exports = JSON.parse('{"name":"automerge-action","version":"0.15.4","description":"GitHub action to automatically merge pull requests","main":"lib/api.js","author":"Pascal","license":"MIT","private":true,"bin":{"automerge-action":"./bin/automerge.js"},"scripts":{"test":"jest","it":"node it/it.js","lint":"prettier -l lib/** test/** && eslint .","compile":"ncc build bin/automerge.js --license LICENSE -o dist","prepublish":"yarn lint && yarn test && yarn compile"},"dependencies":{"@actions/core":"^1.10.0","@octokit/rest":"^19.0.5","argparse":"^2.0.1","fs-extra":"^10.1.0","object-resolve-path":"^1.1.1","tmp":"^0.2.1"},"devDependencies":{"@vercel/ncc":"^0.34.0","dotenv":"^16.0.3","eslint":"^8.25.0","eslint-plugin-jest":"^27.1.2","jest":"^29.2.0","prettier":"^2.7.1"},"prettier":{"trailingComma":"none","arrowParens":"avoid"}}');
+module.exports = JSON.parse('{"name":"automerge-action","version":"0.15.5","description":"GitHub action to automatically merge pull requests","main":"lib/api.js","author":"Pascal","license":"MIT","private":true,"bin":{"automerge-action":"./bin/automerge.js"},"scripts":{"test":"jest","it":"node it/it.js","lint":"prettier -l lib/** test/** && eslint .","compile":"ncc build bin/automerge.js --license LICENSE -o dist","prepublish":"yarn lint && yarn test && yarn compile"},"dependencies":{"@actions/core":"^1.10.0","@octokit/rest":"^19.0.5","argparse":"^2.0.1","fs-extra":"^10.1.0","object-resolve-path":"^1.1.1","tmp":"^0.2.1"},"devDependencies":{"@vercel/ncc":"^0.34.0","dotenv":"^16.0.3","eslint":"^8.25.0","eslint-plugin-jest":"^27.1.2","jest":"^29.2.0","prettier":"^2.7.1"},"prettier":{"trailingComma":"none","arrowParens":"avoid"}}');
 
 /***/ })
 

--- a/lib/merge.js
+++ b/lib/merge.js
@@ -284,6 +284,9 @@ function checkReady(pullRequest, context) {
 
 function mergeable(pullRequest) {
   const { mergeable_state } = pullRequest;
+  logger.info("mergeable_state: ", mergeable_state);
+  logger.info("MAYBE_READY: ", MAYBE_READY);
+  logger.info("MAYBE_READY.includes(mergeable_state): ", MAYBE_READY.includes(mergeable_state));
   if (mergeable_state == null || MAYBE_READY.includes(mergeable_state)) {
     logger.info("PR is probably ready: mergeable_state:", mergeable_state);
     return "success";

--- a/lib/merge.js
+++ b/lib/merge.js
@@ -9,7 +9,7 @@ const {
   retry
 } = require("./common");
 
-const MAYBE_READY = ["clean", "has_hooks", "unknown", "unstable"];
+const MAYBE_READY = ["clean", "has_hooks", "unknown", "unstable", "blocked"];
 const NOT_READY = ["dirty", "draft"];
 
 const PR_PROPERTY = new RegExp("{pullRequest.([^}]+)}", "g");

--- a/lib/merge.js
+++ b/lib/merge.js
@@ -284,9 +284,6 @@ function checkReady(pullRequest, context) {
 
 function mergeable(pullRequest) {
   const { mergeable_state } = pullRequest;
-  logger.info("mergeable_state: ", mergeable_state);
-  logger.info("MAYBE_READY: ", MAYBE_READY);
-  logger.info("MAYBE_READY.includes(mergeable_state): ", MAYBE_READY.includes(mergeable_state));
   if (mergeable_state == null || MAYBE_READY.includes(mergeable_state)) {
     logger.info("PR is probably ready: mergeable_state:", mergeable_state);
     return "success";

--- a/test/merge.test.js
+++ b/test/merge.test.js
@@ -272,7 +272,7 @@ test("Base branch not listed then PR is skipped", async () => {
 test("Unmergeable pull request fails action with non-zero exit code", async () => {
   // GIVEN
   const pr = pullRequest();
-  pr.mergeable_state = "blocked";
+  pr.mergeable_state = "behind";
   const config = createConfig({ MERGE_ERROR_FAIL: "true" });
   octokit.pulls.get = async () => ({ data: pr });
 


### PR DESCRIPTION
Fixes #200 

I understand if you decide you do not want to merge this, as this may not be want the community wants.  I did test this change on our own private repos at my company, and this works *as long as* we use a GH user account to merge that has the appropriate permissions (in our case...a "service user" that can bypass branch protection rules).