### PR TITLE
Improve waitUntilReady

### DIFF
--- a/lib/merge.js
+++ b/lib/merge.js
@@ -256,32 +256,33 @@ function skipPullRequest(context, pullRequest, approvalCount) {
   return skip;
 }
 
-function waitUntilReady(pullRequest, context) {
+async function waitUntilReady(pullRequest, context) {
   const {
     octokit,
     config: { mergeRetries, mergeRetrySleep, mergeErrorFail }
   } = context;
 
+  const checks = await getPullRequestChecks(octokit, pullRequest);
   return retry(
     mergeRetries,
     mergeRetrySleep,
-    () => checkReady(pullRequest, context),
+    () => checkReady(pullRequest, checks, context),
     async () => {
       const pr = await getPullRequest(octokit, pullRequest);
-      return checkReady(pr, context);
+      return checkReady(pr, checks, context);
     },
     () => failOrInfo(mergeRetries, mergeErrorFail)
   );
 }
 
-function checkReady(pullRequest, context) {
+function checkReady(pullRequest, checks, context) {
   if (skipPullRequest(context, pullRequest)) {
     return "failure";
   }
-  return mergeable(pullRequest, context);
+  return mergeable(pullRequest, checks, context);
 }
 
-function mergeable(pullRequest, context) {
+function mergeable(pullRequest, checks, context) {
   const { mergeable_state } = pullRequest;
   const {
     config: { mergeReadyState }
@@ -310,6 +311,19 @@ async function getPullRequest(octokit, pullRequest) {
   logger.trace("PR:", pr);
 
   return pr;
+}
+
+async function getPullRequestChecks(octokit, pullRequest) {
+  logger.debug("Getting PR checks...");
+  const { data: checks } = await octokit.checks.listForRef({
+    owner: pullRequest.base.repo.owner.login,
+    repo: pullRequest.base.repo.name,
+    ref: pullRequest.head.sha,
+  });
+
+  logger.trace("PR checks:", checks);
+
+  return checks;
 }
 
 function tryMerge(

--- a/lib/merge.js
+++ b/lib/merge.js
@@ -286,7 +286,21 @@ function checkReady(pullRequest, checks, context) {
 }
 
 function mergeable(pullRequest, checks, context) {
-  const { mergeable_state } = pullRequest;
+  const { mergeable, mergeable_state } = pullRequest;
+  const areChecksCompleted = checks.check_runs.every(check => check.status === "completed");
+
+  if (mergeable === null) {
+    return "retry";
+  }
+
+  if (!mergeable) {
+    return "failure";
+  }
+
+  if (!areChecksCompleted) {
+    return "retry";
+  }
+
   const {
     config: { mergeReadyState }
   } = context;

--- a/lib/merge.js
+++ b/lib/merge.js
@@ -268,7 +268,10 @@ async function waitUntilReady(pullRequest, context) {
     mergeRetrySleep,
     () => checkReady(pullRequest, checks, context),
     async () => {
-      const pr = await getPullRequest(octokit, pullRequest);
+      const [{ data: pr }, { data: checks }] = await Promise.all([
+        getPullRequest(octokit, pullRequest),
+        getPullRequestChecks(octokit, pullRequest),
+      ]);
       return checkReady(pr, checks, context);
     },
     () => failOrInfo(mergeRetries, mergeErrorFail)


### PR DESCRIPTION
This PR updates waitUntil ready to check:

- `mergeable_state` (already implemented)
- `mergeable` (documented by GH)
- Makes sure PR checks have completed.