### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,7 +273,7 @@ Example usage:
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
       - name: feedback
-        if: steps.automerge.outputs.mergeResult == "merged"
+        if: ${{ steps.automerge.outputs.mergeResult == "merged" }}
         run: |
           echo "Pull request ${{ steps.automerge.outputs.pullRequestNumber }} merged!"
 ```


### PR DESCRIPTION
### Summary

We tried creating a step that would run if the merge failed, but were running into the following error:

```
Invalid workflow file:
The workflow is not valid. .github/workflows/automerge.yml (Line: 40, Col: 13): Unexpected symbol: '"merge_failed"'. Located at position 40 within expression: steps.automerge.outputs.mergeResult == "merge_failed"
```

Wrapping the `if` statement in the [expression syntax](https://docs.github.com/en/actions/learn-github-actions/expressions) fixed this error for us.