### PR TITLE
update javascript runtime to node20

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1,7 +1,7 @@
 name: "Merge pull requests (automerge-action)"
 description: "Automatically merge pull requests that are ready"
 runs:
-  using: "node16"
+  using: "node20"
   main: "dist/index.js"
 branding:
   icon: "git-pull-request"


### PR DESCRIPTION
The latest release of this action causes the following error. I guess the oktokit should be updated with the JS runtime at same time.

```
ERROR fetch is not set. Please pass a fetch implementation as new Octokit({ request: { fetch }}). Learn more at https://github.com/octokit/octokit.js/#fetch-missing
```

> Octokit requires Node 18 or higher, [which includes a native fetch API](https://nodejs.org/en/blog/announcements/v18-release-announce#fetch-(experimental)).