### PR TITLE
Fix permissions configuration in README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,10 +64,11 @@ jobs:
       - id: automerge
         name: automerge
         uses: "pascalgn/automerge-action@v0.16.3"
-        permissions:
-          contents: write
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+    permissions:
+      contents: write
+      pull-requests: read
 ```
 
 For the latest version, see the [list of releases](https://github.com/pascalgn/automerge-action/releases).

--- a/README.md
+++ b/README.md
@@ -60,15 +60,15 @@ on:
 jobs:
   automerge:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: read
     steps:
       - id: automerge
         name: automerge
         uses: "pascalgn/automerge-action@v0.16.3"
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
-    permissions:
-      contents: write
-      pull-requests: read
 ```
 
 For the latest version, see the [list of releases](https://github.com/pascalgn/automerge-action/releases).


### PR DESCRIPTION
This PR addresses an issue with the example workflow configuration in the README, which doesn't work correctly on new repositories with default settings. The problem is due to improper placement of the `permissions` block and missing required permissions. This PR proposes the following changes:

1. Moved the `permissions` block from the step level to the job level.
2. Added the `pull-requests: read` permission, which is necessary for the action to read PR labels.

These changes ensure that the example in the README accurately reflects the correct configuration for the action to work as expected. 